### PR TITLE
Targeting active Ubuntu release, bionic / 18.04

### DIFF
--- a/Dockerfile.advanced
+++ b/Dockerfile.advanced
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y gcc-7 g++-7 cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test1.65-dev libboost-test1.65.1 qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev


### PR DESCRIPTION
Disco / 19.04 was EOL'ed in January 2020. 
Bionic / 18.04 is supported until April 2028.